### PR TITLE
update options in rockspec file

### DIFF
--- a/json-lua-0.1-3.rockspec
+++ b/json-lua-0.1-3.rockspec
@@ -16,7 +16,7 @@ dependencies = {
   "lua >= 5.1"
 }
 build = {
-  type = "module",
+  type = "builtin",
   modules = {
     JSON = "JSON.lua"
   }

--- a/json-lua-0.1-3.rockspec
+++ b/json-lua-0.1-3.rockspec
@@ -2,7 +2,7 @@
 package = "json-lua"
 version = "0.1-3"
 source = {
-  url = "git://github.com/jiyinyiyong/json-lua"
+  url = "git://github.com/jiyinyiyong/json-lua.git"
 }
 description = {
   summary = "JSON encoder/decoder",


### PR DESCRIPTION
1. set full path to git repo. 
I try install via command 'luarocks install json-lua' and receive error:
-----
stat: cannot stat `JSON.lua': No such file or directory
Error: Build error: Failed installing JSON.lua in /usr/local/lib/luarocks/rocks/json-lua/0.1-3/lua
-----
add extension .git - fixed! 
(OS ubuntu 12.04, luarocks 2.0.8, git 1.7.9.5)

2. use 'builtin' instead 'module'
luarocks warning: Do not use 'module' as a build type. Use 'builtin' instead.
on change option - luarocks work normal  
(OS ubuntu 12.04, luarocks 2.0.8, git 1.7.9.5)