### PR TITLE
Use HTTPS url for git checkouts

### DIFF
--- a/json-lua-0.1-3.rockspec
+++ b/json-lua-0.1-3.rockspec
@@ -2,7 +2,7 @@
 package = "json-lua"
 version = "0.1-3"
 source = {
-  url = "git://github.com/jiyinyiyong/json-lua.git"
+  url = "https://github.com/jiyinyiyong/json-lua.git"
 }
 description = {
   summary = "JSON encoder/decoder",


### PR DESCRIPTION
For those who do not have SSH access to GitHub.