### PR TITLE
Use the correct url prefix to do a git checkout over https

### DIFF
--- a/json-lua-0.1-3.rockspec
+++ b/json-lua-0.1-3.rockspec
@@ -2,7 +2,7 @@
 package = "json-lua"
 version = "0.1-3"
 source = {
-  url = "https://github.com/jiyinyiyong/json-lua.git"
+  url = "git+https://github.com/jiyinyiyong/json-lua.git"
 }
 description = {
   summary = "JSON encoder/decoder",


### PR DESCRIPTION
Made a mistake in the previous PR, this fixes it.
Sorry about that.